### PR TITLE
Bootstrap provider

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -1,0 +1,25 @@
+package bootstrap
+
+type BootstrapConfig struct {
+	XDSServers []XDSServer `json:"xds_servers"`
+	Node       Node        `json:"node"`
+}
+
+type XDSServer struct {
+	URI      string   `json:"server_uri"`
+	Features []string `json:"server_features"`
+	Creds    []Cred   `json:"channel_creds"`
+}
+
+type Cred struct {
+	Type string `json:"type"`
+}
+
+type Node struct {
+	ID       string   `json:"id"`
+	Locality Locality `json:"locality,omitempty"`
+}
+
+type Locality struct {
+	Zone string `json:"zone"`
+}

--- a/bootstrap/env.go
+++ b/bootstrap/env.go
@@ -8,15 +8,9 @@ import (
 type envProvider struct{}
 
 func (e *envProvider) Provide(_ context.Context, serverURI string) (*BootstrapConfig, error) {
-	nodeID := os.Getenv("GTC_NODE_ID")
-
-	if nodeID == "" {
-		var err error
-
-		nodeID, err = os.Hostname()
-		if err != nil {
-			return nil, err
-		}
+	nodeID, err := getNodeID()
+	if err != nil {
+		return nil, err
 	}
 
 	return &BootstrapConfig{
@@ -34,4 +28,14 @@ func (e *envProvider) Provide(_ context.Context, serverURI string) (*BootstrapCo
 			},
 		},
 	}, nil
+}
+
+func getNodeID() (string, error) {
+	nodeID := os.Getenv("GTC_NODE_ID")
+
+	if nodeID != "" {
+		return nodeID, nil
+	}
+
+	return os.Hostname()
 }

--- a/bootstrap/env.go
+++ b/bootstrap/env.go
@@ -1,0 +1,37 @@
+package bootstrap
+
+import (
+	"context"
+	"os"
+)
+
+type envProvider struct{}
+
+func (e *envProvider) Provide(_ context.Context, serverURI string) (*BootstrapConfig, error) {
+	nodeID := os.Getenv("GTC_NODE_ID")
+
+	if nodeID == "" {
+		var err error
+
+		nodeID, err = os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &BootstrapConfig{
+		XDSServers: []XDSServer{
+			{
+				URI:      serverURI,
+				Features: []string{"xds_v3"},
+				Creds:    []Cred{{Type: "insecure"}},
+			},
+		},
+		Node: Node{
+			ID: nodeID,
+			Locality: Locality{
+				Zone: os.Getenv("GTC_ZONE"),
+			},
+		},
+	}, nil
+}

--- a/bootstrap/gcloud.go
+++ b/bootstrap/gcloud.go
@@ -1,0 +1,44 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/compute/metadata"
+)
+
+var ErrNotRunningOnGCE = errors.New("not running on GCE")
+
+type gcloudProvider struct{}
+
+func (e *gcloudProvider) Provide(_ context.Context, serverURI string) (*BootstrapConfig, error) {
+	if !metadata.OnGCE() {
+		return nil, ErrNotRunningOnGCE
+	}
+
+	nodeID, err := getNodeID()
+	if err != nil {
+		return nil, err
+	}
+
+	zone, err := metadata.Zone()
+	if err != nil {
+		return nil, err
+	}
+
+	return &BootstrapConfig{
+		XDSServers: []XDSServer{
+			{
+				URI:      serverURI,
+				Features: []string{"xds_v3"},
+				Creds:    []Cred{{Type: "insecure"}},
+			},
+		},
+		Node: Node{
+			ID: nodeID,
+			Locality: Locality{
+				Zone: zone,
+			},
+		},
+	}, nil
+}

--- a/bootstrap/provider.go
+++ b/bootstrap/provider.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	ProviderTypeEnv = "env"
+	ProviderTypeEnv    = "env"
+	ProviderTypeGcloud = "gcloud"
 )
 
 type UnknownProviderError string
@@ -21,10 +22,12 @@ type ConfigProvider interface {
 	Provide(ctx context.Context, serverURI string) (*BootstrapConfig, error)
 }
 
-func BuildConfigProvider(ctx context.Context, providerType string) (ConfigProvider, error) {
+func BuildConfigProvider(_ context.Context, providerType string) (ConfigProvider, error) {
 	switch strings.ToLower(providerType) {
 	case ProviderTypeEnv:
 		return &envProvider{}, nil
+	case ProviderTypeGcloud:
+		return &gcloudProvider{}, nil
 	default:
 		return nil, UnknownProviderError(providerType)
 	}

--- a/bootstrap/provider.go
+++ b/bootstrap/provider.go
@@ -1,0 +1,31 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	ProviderTypeEnv = "env"
+)
+
+type UnknownProviderError string
+
+func (u UnknownProviderError) Error() string {
+	return fmt.Sprintf("unknown bootstrap provider %q", string(u))
+}
+
+// ConfigProvider allows to retrieve a BootstrapConfig.
+type ConfigProvider interface {
+	Provide(ctx context.Context, serverURI string) (*BootstrapConfig, error)
+}
+
+func BuildConfigProvider(ctx context.Context, providerType string) (ConfigProvider, error) {
+	switch strings.ToLower(providerType) {
+	case ProviderTypeEnv:
+		return &envProvider{}, nil
+	default:
+		return nil, UnknownProviderError(providerType)
+	}
+}

--- a/example/k8s/echo-client/1-debug-deployment.yaml
+++ b/example/k8s/echo-client/1-debug-deployment.yaml
@@ -27,13 +27,14 @@ spec:
         - image: ko://github.com/jlevesy/grpc-traffic-controller/cmd/bootstrapgen
           imagePullPolicy: Always
           name: gen-bootstrap
+          env:
+            - name: GTC_ZONE
+              value: zone-a
           args:
             - "-server-uri"
             - "gtc-dev.default.svc.cluster.local:16000"
             - "-out"
             - "/mnt/client/xds-bootstrap.json"
-            - "-zone"
-            - "zone-a"
           volumeMounts:
             - name: xds-bootstrap
               mountPath: /mnt/client


### PR DESCRIPTION
### What Does This PR do?

This PR introduces a provider for bootstrap config. This allows to get different bootstrap configs based on the cloud provider we run on. 

At the moment, only environment and gcloud are supported. But some other are rather easy to add.

Fixes: #93 

### How to Test This PR?

Run the dev env and make some calls. The client call should still be working.

### Good PR Checklist

- [x] Addresses one issue
- [ ] Adds/Updates unit tests
- [ ] Adds/Updates e2e tests
- [ ] Adds/Updates the documentation
- [ ] Opened against the right branch
- [ ] Correctly Labeled
